### PR TITLE
Group reset triggered by first mover only

### DIFF
--- a/Base Project/Main/POUs/XTS/Mover.TcPOU
+++ b/Base Project/Main/POUs/XTS/Mover.TcPOU
@@ -430,8 +430,8 @@ CASE internalState OF
 		fbGroupStatus.Enable			:= TRUE;
 		
 		fbGroupStatus( AxesGroup := GroupReference );	// get current information
-		
-		IF fbGroupStatus.Valid AND fbGroupStatus.GroupErrorStop THEN
+		// trigger reset for group only if this is the first mover in the group
+		IF fbGroupStatus.Valid AND fbGroupStatus.GroupErrorStop AND IdentInGroup = 0 THEN
 			fbGroupReset.Execute		:= TRUE;
 		ELSIF fbGroupStatus.Valid AND fbGroupStatus.GroupDisabled THEN
 			fbGroupReset.Execute		:= FALSE;
@@ -446,7 +446,7 @@ CASE internalState OF
 			ErrorOrigin					:= CONCAT( InstancePath, '.fbGroupStatus' );
 			internalState				:= MV_ERROR;
 		ELSIF fbGroupReset.Error THEN
-			ErrorID						:= fbGroupStatus.ErrorId;
+			ErrorID						:= fbGroupReset.ErrorId;
 			ErrorOrigin					:= CONCAT( InstancePath, '.fbGroupReset' );
 			internalState				:= MV_ERROR;
 		END_IF


### PR DESCRIPTION
When all movers were in error and are then enabled each mover would attempt to reset the group. All but one of the `.fbGroupReset` commands would return an error and one would succeeded, leaving most of the movers still in error.

The code change uses `IdentInGroup` to identify the first mover in the group and only let that one trigger `.fbGroupReset` while the remaining movers continue to monitor the group's status before continuing the enable sequence.

The second line changed (449) is a typo that would not correctly log group reset error codes.