### PR TITLE
Fix issue with movers slightly negative to target position

### DIFF
--- a/Base Project/Main/POUs/XTS/Station.TcPOU
+++ b/Base Project/Main/POUs/XTS/Station.TcPOU
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="Station" Id="{5b67f0b3-4286-49f2-9b21-1e637f521584}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK Station EXTENDS Objective
@@ -40,7 +40,7 @@ FOR i := 0 TO SIZEOF(internalTrackedMovers) / SIZEOF(internalTrackedMovers[0]) -
 
 			difference := Position - internalTrackedMovers[i]^.TrackInfo.TrackPosition;
 			// un-wrap if necessary
-			IF (difference < 0) THEN 
+			IF (difference < -1.0) THEN 
 				difference := difference + GVL.TRACK_LENGTH;
 			END_IF
 	
@@ -106,7 +106,7 @@ FOR i := 0 TO SIZEOF(internalTrackedMovers) / SIZEOF(internalTrackedMovers[0]) -
 		IF (moverTrackId = internalTrackId) THEN
 			difference := Position - internalTrackedMovers[i]^.TrackInfo.TrackPosition;
 			// un-wrap if necessary
-			IF (difference < 0) THEN 
+			IF (difference < -1.0) THEN 
 				difference := difference + GVL.TRACK_LENGTH;
 			END_IF
 

--- a/Base Project/Main/POUs/XTS/Station.TcPOU
+++ b/Base Project/Main/POUs/XTS/Station.TcPOU
@@ -38,13 +38,9 @@ FOR i := 0 TO SIZEOF(internalTrackedMovers) / SIZEOF(internalTrackedMovers[0]) -
 		moverTrackId := internalTrackedMovers[i]^.CurrentTrack^.Id;
 		IF (moverTrackId = internalTrackId) THEN
 
-			difference := Position - internalTrackedMovers[i]^.TrackInfo.TrackPosition;
-			// un-wrap if necessary
-			IF (difference < -1.0) THEN 
-				difference := difference + GVL.TRACK_LENGTH;
-			END_IF
-	
-			IF (difference < 1.0) AND NOT internalTrackedMovers[i]^.Busy THEN
+			difference := ABS(internalTrackedMovers[i]^.TrackInfo.TrackPosition - Position);
+
+			IF MIN(difference, GVL.TRACK_LENGTH - difference) < 1.0 AND NOT internalTrackedMovers[i]^.Busy THEN
 				CurrentMover                    REF= internalTrackedMovers[i]^;
 				CurrentMover.SourceInstancePath := THIS^.InstancePath;
 			END_IF
@@ -105,12 +101,8 @@ FOR i := 0 TO SIZEOF(internalTrackedMovers) / SIZEOF(internalTrackedMovers[0]) -
 		moverTrackId := internalTrackedMovers[i]^.CurrentTrack^.Id;
 		IF (moverTrackId = internalTrackId) THEN
 			difference := Position - internalTrackedMovers[i]^.TrackInfo.TrackPosition;
-			// un-wrap if necessary
-			IF (difference < -1.0) THEN 
-				difference := difference + GVL.TRACK_LENGTH;
-			END_IF
 
-			IF (difference < 1.0) AND NOT internalTrackedMovers[i]^.Busy THEN
+			IF MIN(difference, GVL.TRACK_LENGTH - difference) < 1.0 AND NOT internalTrackedMovers[i]^.Busy THEN
 				MoverInPosition := TRUE;
 			END_IF
 		END_IF;

--- a/Base Project/_Config/PLC/Main.xti
+++ b/Base Project/_Config/PLC/Main.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.47" ClassName="CNestedPlcProjDef">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
@@ -1343,7 +1343,7 @@ and will return to Group State Standby when the situation permits.
 		</DataType>
 	</DataTypes>
 	<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="Main" PrjFilePath="..\..\Main\Main.plcproj" TmcFilePath="..\..\Main\Main.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Main\Main.tmc" TmcHash="{1D58347C-4FF6-5B71-33A8-F6AD1E8ECDDD}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Main\Main.tmc" TmcHash="{D9B92027-E99D-36FF-9A29-1182C45ECA1D}">
 			<Name>Main Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
It was possible with a mover that slightly undershoots a station that it would not be detected within the 1.0mm position tolerance of the station.