### PR TITLE
Changes to Recovery

### DIFF
--- a/Base Project/Base Project.tsproj
+++ b/Base Project/Base Project.tsproj
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.59">
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.60">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{C929B002-BF94-48A2-937B-5D20DED8EF3B}">OperationMode</Name>

--- a/Base Project/Main/POUs/MAIN.TcPOU
+++ b/Base Project/Main/POUs/MAIN.TcPOU
@@ -75,7 +75,7 @@ CASE MainState OF
 	MainStateMachine_enum.MS_ENABLED:	// -------------------------------------------
 	
 		// Recovery logic
-		IF MainCommands.Start THEN
+		IF MainCommands.Start AND system.AllMotorModulesReady AND system.GroupEnabled THEN
 			System.CompleteMoverList.SetAllVelocity(mediumVelocity).MoveAllToStation( Station[0] );
 			System.ResetStatistics();
 			// Reinit nextStation

--- a/Base Project/Main/POUs/MAIN.TcPOU
+++ b/Base Project/Main/POUs/MAIN.TcPOU
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.13">
   <POU Name="MAIN" Id="{c992ed33-41fe-02c4-17ef-23123b9a5b23}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM MAIN
 VAR	
@@ -31,13 +31,15 @@ VAR
 	
 	// ========= Example Application Variables =========
 
-    nextStation 		: USINT := 4;
+    nextStation 			: USINT := 4;
                     	
-    lowVelocity    		: LREAL := 200;  	// mm/s
-    mediumVelocity 		: LREAL := 800;  	// mm/s
-    highVelocity   		: LREAL := 1200; 	// mm/s
+    lowVelocity    			: LREAL := 200;  	// mm/s
+    mediumVelocity 			: LREAL := 800;  	// mm/s
+    highVelocity   			: LREAL := 1200; 	// mm/s
 	
-	StationTimer 		: ARRAY[0..GVL.NUM_STATIONS] OF TON; // timer blocks, for station dwells
+	StationTimer 			: ARRAY[0..GVL.NUM_STATIONS] OF TON; // timer blocks, for station dwells
+	InitialParameterSet		: MotionParameters_typ;
+	
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -163,14 +165,15 @@ System.Cyclic();
 
 	Zone[3].StartPosition		:= 2750;
 	Zone[3].EndPosition   		:= 3750;
+
+	InitialParameterSet.Velocity		:= 1000;		// mm/s
+	InitialParameterSet.Acceleration	:= 10_000;		// mm/s2
+	InitialParameterSet.Deceleration	:= 10_000;		// mm/s2
+	InitialParameterSet.Jerk			:= 100_000;		// mm/s3
+	InitialParameterSet.Gap				:= 85;			// mm
+	InitialParameterSet.Direction		:= mcDirectionPositive;	
 	
-	System.CompleteMoverList.SetAllVelocity( 1E3 );
-	System.CompleteMoverList.SetAllAcceleration( 1E4 );
-	System.CompleteMoverList.SetAllDeceleration( 1E4 );
-	System.CompleteMoverList.SetAllJerk( 5E5 );
-	System.CompleteMoverList.SetAllGap( 85 );
-	System.CompleteMoverList.SetAllDirection( mcDirectionPositive );
-	]]></ST>
+	System.CompleteMoverList.ApplyAllParameterSet( InitialParameterSet );]]></ST>
       </Implementation>
     </Action>
     <Action Name="Registering" Id="{ef3ef836-2b88-0099-2899-1cd10004220b}">
@@ -276,5 +279,28 @@ System.Cyclic();
         END_IF]]></ST>
       </Implementation>
     </Action>
+    <LineIds Name="MAIN">
+      <LineId Id="3" Count="93" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="MAIN.Initializing">
+      <LineId Id="2" Count="23" />
+      <LineId Id="34" Count="0" />
+      <LineId Id="43" Count="0" />
+      <LineId Id="48" Count="0" />
+      <LineId Id="47" Count="0" />
+      <LineId Id="49" Count="1" />
+      <LineId Id="46" Count="0" />
+      <LineId Id="44" Count="0" />
+      <LineId Id="41" Count="0" />
+    </LineIds>
+    <LineIds Name="MAIN.Registering">
+      <LineId Id="2" Count="31" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
+    <LineIds Name="MAIN.StationLogic">
+      <LineId Id="2" Count="60" />
+      <LineId Id="1" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
+++ b/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
@@ -357,8 +357,9 @@ END_IF]]></ST>
 	J				: UDINT;
 	nParts			: UDINT;
 	nModulesInPart	: UDINT;
-END_VAR
-]]></Declaration>
+	
+	DriveStatusStorage: INT;
+END_VAR]]></Declaration>
         <Implementation>
           <ST><![CDATA[// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
 IF fbXtsEnvironment.P_IsInitialized THEN
@@ -370,7 +371,8 @@ IF fbXtsEnvironment.P_IsInitialized THEN
 		FOR I := 1 TO nParts DO 
 			nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).GetModuleCount();
 			FOR J := 1 TO nModulesInPart DO
-				IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).ModuleTcIo(UDINT_TO_UINT(J)).GetDriveStatusValue() = 4135) AND NOT fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation THEN
+				DriveStatusStorage:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).ModuleTcIo(UDINT_TO_UINT(J)).GetDriveStatusValue();
+				IF NOT (DriveStatusStorage = 4135) AND NOT (fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation) THEN
 					bHighDriveReady:= FALSE;
 				END_IF 
 			END_FOR
@@ -967,7 +969,7 @@ END_VAR
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="Mediator.AllMotorModulesReady.Get">
-      <LineId Id="58" Count="16" />
+      <LineId Id="91" Count="17" />
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="Mediator.CompleteMoverList.Get">

--- a/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
+++ b/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.13">
   <POU Name="Mediator" Id="{164d51b4-07ec-0e46-0eb0-392af39d7d3a}" SpecialFunc="None">
     <Declaration><![CDATA[{attribute 'reflection'}
 FUNCTION_BLOCK Mediator
@@ -51,6 +51,7 @@ VAR
 	fbGroupEnable			: MC_GroupEnable;
 	fbGroupReset			: MC_GroupReset;
 	fbGroupStop				: MC_GroupStop;
+	bHighDriveReady: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -396,6 +397,12 @@ VAR_INST
 	StopPositions	: ARRAY [1..TcIoXtsEnvironmentParameterList.MaxXtsStopPositionsPerStation] OF LREAL := [0.0];
 	i				: UDINT;
 	j				: UDINT;
+	
+	H				: UDINT;
+	U				: UDINT;
+	nDriveStatus	: INT;
+	nParts			: UDINT;
+	nModulesInPart	: UDINT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// this method contains multiple state machines denoted by the headers below
@@ -745,6 +752,29 @@ IF THIS^.InfoServerIsReady AND internalEnabled AND GVL.AUTO_POPULATE_STATIONS TH
 	END_CASE
 
 
+END_IF
+
+// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
+IF fbXtsEnvironment.P_IsInitialized THEN
+CASE nDriveStatus OF
+	0:// Get number of parts. 
+		//Environment.XpuTcIo(1).PartTcIo(1).ModuleTcIo(1).GetDriveState() 
+	nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
+	IF nParts <> 0 THEN
+		nDriveStatus:= 10;
+	END_IF
+	
+	10:// Get number of modules per part and check their state
+	bHighDriveReady:= TRUE;
+	FOR H := 1 TO nParts DO 
+		nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).GetModuleCount();
+		FOR U := 1 TO nModulesInPart DO
+			IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).ModuleTcIo(UDINT_TO_UINT(U)).GetDriveStatusValue() = 4135) THEN
+				bHighDriveReady:= FALSE;
+			END_IF 
+		END_FOR
+	END_FOR
+END_CASE
 END_IF]]></ST>
       </Implementation>
     </Method>
@@ -815,6 +845,17 @@ END_VAR
         <Implementation>
           <ST><![CDATA[// sum of various error bits throughout the mediator
 GroupError := fbGroupStatus.GroupErrorStop;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
+    <Property Name="HighDriveReady" Id="{e4a76f20-75da-0820-2f6d-be0ad375c645}" FolderPath="Properties\">
+      <Declaration><![CDATA[PROPERTY HighDriveReady : Bool]]></Declaration>
+      <Get Name="Get" Id="{f8eb48d2-a530-04d2-2b29-7da0e49d088b}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[HighDriveReady:= bHighDriveReady;]]></ST>
         </Implementation>
       </Get>
     </Property>
@@ -902,5 +943,90 @@ END_VAR
         </Implementation>
       </Get>
     </Property>
+    <LineIds Name="Mediator">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.AddMover">
+      <LineId Id="3" Count="41" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.AddMoverList">
+      <LineId Id="3" Count="24" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.AddPositionTrigger">
+      <LineId Id="3" Count="32" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.AddStation">
+      <LineId Id="3" Count="24" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.AddTrack">
+      <LineId Id="3" Count="24" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.AddZone">
+      <LineId Id="3" Count="32" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.CompleteMoverList.Get">
+      <LineId Id="3" Count="7" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.Cyclic">
+      <LineId Id="3" Count="346" />
+      <LineId Id="2" Count="0" />
+      <LineId Id="384" Count="21" />
+      <LineId Id="383" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.DetectMover1">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.EnableGroup">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.Environment.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.EnvironmentIsReady.Get">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.GroupEnabled.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.GroupError.Get">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.HighDriveReady.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.InfoServer.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.InfoServerIsReady.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.InstancePath.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.Mover1DetectionComplete.Get">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.Mover1DetectionError.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.ResetStatistics">
+      <LineId Id="3" Count="6" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mediator.XPU.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
+++ b/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
@@ -769,7 +769,7 @@ CASE nDriveStatus OF
 	FOR H := 1 TO nParts DO 
 		nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).GetModuleCount();
 		FOR U := 1 TO nModulesInPart DO
-			IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).ModuleTcIo(UDINT_TO_UINT(U)).GetDriveStatusValue() = 4135) THEN
+			IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).ModuleTcIo(UDINT_TO_UINT(U)).GetDriveStatusValue() = 4135) and not fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation THEN
 				bHighDriveReady:= FALSE;
 			END_IF 
 		END_FOR

--- a/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
+++ b/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
@@ -15,11 +15,6 @@ VAR_INPUT
 
 	GROUP_REF				: AXES_GROUP_REF;
 	
-	
-	H				: UDINT;
-	U				: UDINT;
-	nParts			: UDINT;
-	nModulesInPart	: UDINT;
 END_VAR
 VAR_OUTPUT
 	Error			: BOOL;			// error is currently active
@@ -354,6 +349,38 @@ IF __ISVALIDREF( Zone ) THEN
 END_IF]]></ST>
       </Implementation>
     </Method>
+    <Property Name="AllMotorModulesReady" Id="{e4a76f20-75da-0820-2f6d-be0ad375c645}" FolderPath="Properties\">
+      <Declaration><![CDATA[PROPERTY AllMotorModulesReady : Bool]]></Declaration>
+      <Get Name="Get" Id="{f8eb48d2-a530-04d2-2b29-7da0e49d088b}">
+        <Declaration><![CDATA[VAR
+	I				: UDINT;
+	J				: UDINT;
+	nParts			: UDINT;
+	nModulesInPart	: UDINT;
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
+IF fbXtsEnvironment.P_IsInitialized THEN
+// Get number of parts. 
+	nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
+	IF nParts <> 0 THEN
+// Get number of modules per part and check their state
+		bHighDriveReady:= TRUE;
+		FOR I := 1 TO nParts DO 
+			nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).GetModuleCount();
+			FOR J := 1 TO nModulesInPart DO
+				IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).ModuleTcIo(UDINT_TO_UINT(J)).GetDriveStatusValue() = 4135) AND NOT fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation THEN
+					bHighDriveReady:= FALSE;
+				END_IF 
+			END_FOR
+		END_FOR
+	END_IF
+END_IF
+AllMotorModulesReady:= bHighDriveReady;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
     <Property Name="CompleteMoverList" Id="{41f8f92e-6d81-02a1-048b-3da9baf27ff9}" FolderPath="Properties\">
       <Declaration><![CDATA[PROPERTY CompleteMoverList : iMoverList]]></Declaration>
       <Get Name="Get" Id="{0ba48769-41e2-05d1-1ed6-465e4a354ad7}">
@@ -828,34 +855,6 @@ GroupError := fbGroupStatus.GroupErrorStop;]]></ST>
         </Implementation>
       </Get>
     </Property>
-    <Property Name="HighDriveReady" Id="{e4a76f20-75da-0820-2f6d-be0ad375c645}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY HighDriveReady : Bool]]></Declaration>
-      <Get Name="Get" Id="{f8eb48d2-a530-04d2-2b29-7da0e49d088b}">
-        <Declaration><![CDATA[VAR
-END_VAR
-]]></Declaration>
-        <Implementation>
-          <ST><![CDATA[// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
-IF fbXtsEnvironment.P_IsInitialized THEN
-// Get number of parts. 
-	nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
-	IF nParts <> 0 THEN
-// Get number of modules per part and check their state
-		bHighDriveReady:= TRUE;
-		FOR H := 1 TO nParts DO 
-			nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).GetModuleCount();
-			FOR U := 1 TO nModulesInPart DO
-				IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).ModuleTcIo(UDINT_TO_UINT(U)).GetDriveStatusValue() = 4135) AND NOT fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation THEN
-					bHighDriveReady:= FALSE;
-				END_IF 
-			END_FOR
-		END_FOR
-	END_IF
-END_IF
-HighDriveReady:= bHighDriveReady;]]></ST>
-        </Implementation>
-      </Get>
-    </Property>
     <Property Name="InfoServer" Id="{816a507a-b5f1-077f-3d31-6cc9a0af8cb5}" FolderPath="Properties\">
       <Declaration><![CDATA[PROPERTY InfoServer : I_TcIoXtsInfoServer]]></Declaration>
       <Get Name="Get" Id="{880f5fd5-5a90-005a-341d-63c8b7f4f011}">
@@ -967,6 +966,10 @@ END_VAR
       <LineId Id="3" Count="32" />
       <LineId Id="2" Count="0" />
     </LineIds>
+    <LineIds Name="Mediator.AllMotorModulesReady.Get">
+      <LineId Id="58" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
     <LineIds Name="Mediator.CompleteMoverList.Get">
       <LineId Id="3" Count="7" />
       <LineId Id="2" Count="0" />
@@ -997,11 +1000,6 @@ END_VAR
     </LineIds>
     <LineIds Name="Mediator.GroupError.Get">
       <LineId Id="3" Count="0" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="Mediator.HighDriveReady.Get">
-      <LineId Id="6" Count="15" />
-      <LineId Id="5" Count="0" />
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="Mediator.InfoServer.Get">

--- a/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
+++ b/Base Project/Main/POUs/XTS/Administrative/Mediator.TcPOU
@@ -15,6 +15,11 @@ VAR_INPUT
 
 	GROUP_REF				: AXES_GROUP_REF;
 	
+	
+	H				: UDINT;
+	U				: UDINT;
+	nParts			: UDINT;
+	nModulesInPart	: UDINT;
 END_VAR
 VAR_OUTPUT
 	Error			: BOOL;			// error is currently active
@@ -398,11 +403,7 @@ VAR_INST
 	i				: UDINT;
 	j				: UDINT;
 	
-	H				: UDINT;
-	U				: UDINT;
-	nDriveStatus	: INT;
-	nParts			: UDINT;
-	nModulesInPart	: UDINT;
+
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// this method contains multiple state machines denoted by the headers below
@@ -754,28 +755,7 @@ IF THIS^.InfoServerIsReady AND internalEnabled AND GVL.AUTO_POPULATE_STATIONS TH
 
 END_IF
 
-// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
-IF fbXtsEnvironment.P_IsInitialized THEN
-CASE nDriveStatus OF
-	0:// Get number of parts. 
-		//Environment.XpuTcIo(1).PartTcIo(1).ModuleTcIo(1).GetDriveState() 
-	nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
-	IF nParts <> 0 THEN
-		nDriveStatus:= 10;
-	END_IF
-	
-	10:// Get number of modules per part and check their state
-	bHighDriveReady:= TRUE;
-	FOR H := 1 TO nParts DO 
-		nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).GetModuleCount();
-		FOR U := 1 TO nModulesInPart DO
-			IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).ModuleTcIo(UDINT_TO_UINT(U)).GetDriveStatusValue() = 4135) and not fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation THEN
-				bHighDriveReady:= FALSE;
-			END_IF 
-		END_FOR
-	END_FOR
-END_CASE
-END_IF]]></ST>
+]]></ST>
       </Implementation>
     </Method>
     <Method Name="DetectMover1" Id="{1d387785-e892-0967-22d4-73d2923e67ae}" FolderPath="Methods\">
@@ -855,7 +835,24 @@ GroupError := fbGroupStatus.GroupErrorStop;]]></ST>
 END_VAR
 ]]></Declaration>
         <Implementation>
-          <ST><![CDATA[HighDriveReady:= bHighDriveReady;]]></ST>
+          <ST><![CDATA[// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
+IF fbXtsEnvironment.P_IsInitialized THEN
+// Get number of parts. 
+	nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
+	IF nParts <> 0 THEN
+// Get number of modules per part and check their state
+		bHighDriveReady:= TRUE;
+		FOR H := 1 TO nParts DO 
+			nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).GetModuleCount();
+			FOR U := 1 TO nModulesInPart DO
+				IF NOT (fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(H)).ModuleTcIo(UDINT_TO_UINT(U)).GetDriveStatusValue() = 4135) AND NOT fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation THEN
+					bHighDriveReady:= FALSE;
+				END_IF 
+			END_FOR
+		END_FOR
+	END_IF
+END_IF
+HighDriveReady:= bHighDriveReady;]]></ST>
         </Implementation>
       </Get>
     </Property>
@@ -977,8 +974,8 @@ END_VAR
     <LineIds Name="Mediator.Cyclic">
       <LineId Id="3" Count="346" />
       <LineId Id="2" Count="0" />
-      <LineId Id="384" Count="21" />
-      <LineId Id="383" Count="0" />
+      <LineId Id="384" Count="0" />
+      <LineId Id="439" Count="0" />
     </LineIds>
     <LineIds Name="Mediator.DetectMover1">
       <LineId Id="3" Count="1" />
@@ -1003,6 +1000,8 @@ END_VAR
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="Mediator.HighDriveReady.Get">
+      <LineId Id="6" Count="15" />
+      <LineId Id="5" Count="0" />
       <LineId Id="2" Count="0" />
     </LineIds>
     <LineIds Name="Mediator.InfoServer.Get">

--- a/Base Project/Main/POUs/XTS/Mover.TcPOU
+++ b/Base Project/Main/POUs/XTS/Mover.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.13">
   <POU Name="Mover" Id="{461a92b9-026e-4cbb-aa50-b18297f25ecc}" SpecialFunc="None">
     <Declaration><![CDATA[{attribute 'reflection'}
 FUNCTION_BLOCK Mover IMPLEMENTS iMover;
@@ -238,6 +238,7 @@ MotionParameters.Acceleration	:= LIMIT( 0, MotionParameters.Acceleration, 1E300 
 MotionParameters.Deceleration	:= LIMIT( 0, MotionParameters.Deceleration, 1E300 );
 MotionParameters.Jerk			:= LIMIT( 0, MotionParameters.Jerk, 1E300 );
 MotionParameters.Velocity		:= LIMIT( 0, MotionParameters.Velocity, 1E300 );
+AxisReference.ReadStatus();
 
 CASE internalState OF
 	MV_IDLE:	// ------------------------------------------------------- idle state
@@ -259,6 +260,7 @@ CASE internalState OF
 			fbHaltCA.Execute				:= FALSE;
 			fbAddToGroup.Execute			:= FALSE;
 			fbRemoveFromGroup.Execute		:= FALSE;
+			fbReset.Execute					:= FALSE;
 		
 			internalEnable		:= FALSE;
 			internalState		:= MV_RESET;
@@ -348,7 +350,8 @@ CASE internalState OF
 	MV_ENABLEGROUP:	// ----------------------------------------------- have mediator enable group
 		IF NOT Mediator.GroupEnabled THEN
 			Mediator.EnableGroup();
-		ELSE
+		END_IF
+		IF Mediator.GroupEnabled AND Mediator.HighDriveReady THEN
 			internalState := MV_RUN;
 		END_IF
 	
@@ -455,6 +458,10 @@ CASE internalState OF
 			ErrorID					:= fbActivateTrack.ErrorId;
 			ErrorOrigin				:= CONCAT( InstancePath, '.fbActivateTrack');
 			internalState			:= MV_ERROR;
+		ELSIF AxisReference.Status.Error THEN
+			ErrorID					:= AxisReference.Status.ErrorID;
+			ErrorOrigin				:= Concat(InstancePath, '.GeneralNCerror');
+			InternalState			:= MV_ERROR;
 		END_IF
 		
 	MV_BEGIN_HALTING:	// --------------------------------------------------- begin stopping process
@@ -552,6 +559,9 @@ CASE internalState OF
 		Ready	:= FALSE;
 		Busy	:= FALSE;
 		Error	:= TRUE;
+		
+		internalReissue := FALSE;
+		InternalCurrentMoveType:= MOVETYPE_NONE;
 		
 		internalEnable			:= FALSE;		
 		IF internalDisable THEN
@@ -1887,5 +1897,160 @@ END_IF
 lastCallValidateTrack		:= newCallTime;]]></ST>
       </Implementation>
     </Method>
+    <LineIds Name="Mover">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.ActivateTrack">
+      <LineId Id="3" Count="25" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.CurrentDestinationPosition.Get">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.CurrentDestinationTrack.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.CurrentMoveType.Get">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.CurrentObjective.Get">
+      <LineId Id="3" Count="0" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.CurrentTrack.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.Cyclic">
+      <LineId Id="3" Count="11" />
+      <LineId Id="488" Count="0" />
+      <LineId Id="15" Count="19" />
+      <LineId Id="489" Count="0" />
+      <LineId Id="35" Count="89" />
+      <LineId Id="490" Count="0" />
+      <LineId Id="125" Count="105" />
+      <LineId Id="492" Count="2" />
+      <LineId Id="491" Count="0" />
+      <LineId Id="231" Count="96" />
+      <LineId Id="496" Count="0" />
+      <LineId Id="328" Count="0" />
+      <LineId Id="495" Count="0" />
+      <LineId Id="329" Count="0" />
+      <LineId Id="497" Count="0" />
+      <LineId Id="330" Count="148" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.Disable">
+      <LineId Id="3" Count="13" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.Enable">
+      <LineId Id="3" Count="14" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.GroupStop">
+      <LineId Id="3" Count="30" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.Halt">
+      <LineId Id="3" Count="41" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.IsSyncedToAxis.Get">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.IsSyncedToMover.Get">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.IsTrackReady.Get">
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.LogUserEvent">
+      <LineId Id="3" Count="6" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.MasterMover.Get">
+      <LineId Id="3" Count="5" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.MoveToPosition">
+      <LineId Id="3" Count="82" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.MoveToStation">
+      <LineId Id="3" Count="86" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.MoveVelocity">
+      <LineId Id="3" Count="85" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.NextMover.Get">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.Payload.Get">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.Payload.Set">
+      <LineId Id="3" Count="1" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.PreviousMover.Get">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.ReissueCommand">
+      <LineId Id="3" Count="4" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetAcceleration">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetDeceleration">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetDirection">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetGap">
+      <LineId Id="3" Count="15" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetGapMode">
+      <LineId Id="3" Count="27" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetJerk">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SetVelocity">
+      <LineId Id="3" Count="16" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SyncToAxis">
+      <LineId Id="3" Count="104" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.SyncToMover">
+      <LineId Id="3" Count="102" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.UnregisterFromAll">
+      <LineId Id="3" Count="14" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
+    <LineIds Name="Mover.ValidateTrack">
+      <LineId Id="3" Count="14" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>

--- a/Base Project/Main/POUs/XTS/Mover.TcPOU
+++ b/Base Project/Main/POUs/XTS/Mover.TcPOU
@@ -103,6 +103,7 @@ VAR
 	lastCallSetGap		: LREAL;
 	lastCallActivateTrack : LREAL;
 	
+	TestVar: BOOL;
 END_VAR
 VAR_IN_OUT
 	
@@ -352,7 +353,7 @@ CASE internalState OF
 		END_IF
 		
 	MV_ENABLEGROUP:	// ----------------------------------------------- have mediator enable group
-
+		TestVar:= Mediator.AllMotorModulesReady;
 		IF Mediator.GroupEnabled AND Mediator.AllMotorModulesReady THEN
 			internalState := MV_RUN;
 		END_IF

--- a/Base Project/Main/POUs/XTS/Mover.TcPOU
+++ b/Base Project/Main/POUs/XTS/Mover.TcPOU
@@ -249,6 +249,8 @@ CASE internalState OF
 		internalDisable			:= FALSE;
 		IF internalEnable THEN
 			// clear enable on commands (allows commands to hold error IDs until next enable signle for debugging
+			
+			internalReissue					:= FALSE;
 			fbMoveAbsCA[0].Execute			:= FALSE;
 			fbMoveAbsCA[1].Execute			:= FALSE;
 			fbMoveRelCA[0].Execute			:= FALSE;
@@ -340,6 +342,8 @@ CASE internalState OF
 			InGroup						:= TRUE;
 			IdentInGroup				:= AxisReference.NcToPlc.AxisId - 1;
 			fbAddToGroup.Execute		:= FALSE;
+			
+			Mediator.EnableGroup();
 			internalState				:= MV_ENABLEGROUP;
 		ELSIF fbAddToGroup.Error THEN
 			ErrorID						:= fbAddToGroup.ErrorId;
@@ -348,14 +352,11 @@ CASE internalState OF
 		END_IF
 		
 	MV_ENABLEGROUP:	// ----------------------------------------------- have mediator enable group
-		IF NOT Mediator.GroupEnabled THEN
-			Mediator.EnableGroup();
-		END_IF
-		IF Mediator.GroupEnabled AND Mediator.HighDriveReady THEN
+
+		IF Mediator.GroupEnabled AND Mediator.AllMotorModulesReady THEN
 			internalState := MV_RUN;
 		END_IF
-	
-		
+			
 	MV_RUN: // ------------------------------------------------------- mover enabled, ready
 	
 		Ready	:= TRUE;
@@ -460,7 +461,7 @@ CASE internalState OF
 			internalState			:= MV_ERROR;
 		ELSIF AxisReference.Status.Error THEN
 			ErrorID					:= AxisReference.Status.ErrorID;
-			ErrorOrigin				:= Concat(InstancePath, '.GeneralNCerror');
+			ErrorOrigin				:= Concat(InstancePath, ': General NC Error');
 			InternalState			:= MV_ERROR;
 		END_IF
 		
@@ -560,7 +561,6 @@ CASE internalState OF
 		Busy	:= FALSE;
 		Error	:= TRUE;
 		
-		internalReissue := FALSE;
 		InternalCurrentMoveType:= MOVETYPE_NONE;
 		
 		internalEnable			:= FALSE;		
@@ -1925,16 +1925,22 @@ lastCallValidateTrack		:= newCallTime;]]></ST>
     <LineIds Name="Mover.Cyclic">
       <LineId Id="3" Count="11" />
       <LineId Id="488" Count="0" />
-      <LineId Id="15" Count="19" />
+      <LineId Id="15" Count="8" />
+      <LineId Id="507" Count="1" />
+      <LineId Id="24" Count="10" />
       <LineId Id="489" Count="0" />
-      <LineId Id="35" Count="89" />
+      <LineId Id="35" Count="78" />
+      <LineId Id="511" Count="0" />
+      <LineId Id="510" Count="0" />
+      <LineId Id="114" Count="7" />
+      <LineId Id="124" Count="0" />
       <LineId Id="490" Count="0" />
-      <LineId Id="125" Count="105" />
+      <LineId Id="125" Count="2" />
+      <LineId Id="129" Count="101" />
       <LineId Id="492" Count="2" />
       <LineId Id="491" Count="0" />
       <LineId Id="231" Count="96" />
       <LineId Id="496" Count="0" />
-      <LineId Id="328" Count="0" />
       <LineId Id="495" Count="0" />
       <LineId Id="329" Count="0" />
       <LineId Id="497" Count="0" />

--- a/Base Project/_Config/PLC/Main.xti
+++ b/Base Project/_Config/PLC/Main.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.59" ClassName="CNestedPlcProjDef">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.60" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{DB9169AE-6AF9-4994-9F36-F1067592C967}" Namespace="MC">MC_GROUP_TYPE</Name>
@@ -1305,7 +1305,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="Main" PrjFilePath="..\..\Main\Main.plcproj" TmcFilePath="..\..\Main\Main.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Main\Main.tmc" TmcHash="{5CB9E5ED-CAFC-696A-9B9E-D31195D76E5F}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="Main\Main.tmc" TmcHash="{973128FA-45CC-7CAC-EA2B-6B533404096D}">
 			<Name>Main Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
Making sure Movers can't issue or reissue motion commands during the transition from a fault condition back to the Mover's internal run state.