### PR TITLE
Resolve off-by-one in Objective.RegisterMoverList method

### DIFF
--- a/Base Project/Base Project.tsproj
+++ b/Base Project/Base Project.tsproj
@@ -32098,7 +32098,7 @@ External Setpoint Generation:
 		</Motion>
 		<Plc>
 			<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="PLC1" PrjFilePath="PLC1\PLC1.plcproj" TmcFilePath="PLC1\PLC1.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{EF401F15-6079-0CBF-97AC-9E4A6BA8DF55}" TmcPath="PLC1\PLC1.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{661B1C71-09B1-0524-E423-425D6EDE9255}" TmcPath="PLC1\PLC1.tmc">
 					<Name>PLC1 Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="2" AreaNo="1">

--- a/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Objective.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Objective.TcPOU
@@ -130,7 +130,7 @@ VAR
     i                : ULINT;
     duplicateFound   : BOOL;
     emptyIDX         : USINT;
-    arrTrackedMovers : ARRAY[0..(Param.MAX_MOVERS - 1)] OF POINTER TO Mover;
+    arrTrackedMovers : ARRAY[1..(Param.MAX_MOVERS)] OF POINTER TO Mover;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[(*
@@ -141,7 +141,7 @@ arrTrackedMovers := NewMoverList.RegisteredMovers;
 
 // IF __ISVALIDREF( NewMoverList ) THEN
 IF NewMoverList <> 0 THEN
-    FOR i := 1 TO SIZEOF(arrTrackedMovers) / SIZEOF(arrTrackedMovers[0]) DO
+    FOR i := 1 TO SIZEOF(arrTrackedMovers) / SIZEOF(arrTrackedMovers[1]) DO
 
         THIS^.RegisterMover(arrTrackedMovers[i]^);
 


### PR DESCRIPTION
This method was using a 0.99 based array but counting 1-100 in the for loop. The result was the in some specific cases the 100th array index would have data in it (because it was a temporary array on the stack) and this would be interpreted as a mover in this slot in the array. The descendent, such as a zone, would then receive a mover list with a pointer to something that was not a mover. This could cause errors when performing work on the Zone's (or station, position trigger, etc.) mover list such as GetMoverByLocation().