### PR TITLE
Allow for spares station array when populating stations automatically

### DIFF
--- a/Base Project/Base Project.tsproj
+++ b/Base Project/Base Project.tsproj
@@ -32098,7 +32098,7 @@ External Setpoint Generation:
 		</Motion>
 		<Plc>
 			<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="PLC1" PrjFilePath="PLC1\PLC1.plcproj" TmcFilePath="PLC1\PLC1.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{838987AC-37BF-B2BA-5D8A-BEC0DAF0DC93}" TmcPath="PLC1\PLC1.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{729908B8-FCA7-4BA9-D747-EC0CB626B9F8}" TmcPath="PLC1\PLC1.tmc">
 					<Name>PLC1 Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="2" AreaNo="1">

--- a/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
@@ -436,6 +436,7 @@ VAR_INST
 	StopPositions	: ARRAY [1..TcIoXtsEnvironmentParameterList.MaxXtsStopPositionsPerStation] OF LREAL := [0.0];
 	i				: UDINT;
 	j				: UDINT;
+	workingStation	: UDINT;
 	
 	XPUDetectionState	: DetectionStateEnum;
 END_VAR]]></Declaration>
@@ -781,9 +782,19 @@ IF THIS^.InfoServerIsReady AND internalEnabled AND Param.AUTO_POPULATE_STATIONS 
 		40:
 			// calculate minimum number of stations that can be set up
 			nUsableStations := MIN(nInfoServerStations, Param.NUM_STATIONS);
+			workingStation := 0;
 			FOR i := 1 TO nUsableStations DO
+				workingStation := workingStation + 1;
+				// in case a sparse Station array is used, only detect stations that have a position value <> 0
+				WHILE (workingStation < Param.NUM_STATIONS AND_THEN (StationArray[workingStation] = 0 OR_ELSE StationArray[workingStation]^.Position = 0)) DO
+					workingStation := workingStation + 1;
+				END_WHILE
+				// check for valid working station, and exit this for loop iteration if we're outside it
+				IF workingStation >= Param.NUM_STATIONS THEN
+					EXIT;
+				END_IF
 				// get XTS_Base Station pointer
-				xtsStationPointer := StationArray[i];
+				xtsStationPointer := StationArray[workingStation];
 				// test for valid pointer (station has been through the Mediator.AddStation method)
 				IF (xtsStationPointer <> 0) THEN
 					// dereference the pointer

--- a/Documentation/docs/GettingStarted/Visualization.md
+++ b/Documentation/docs/GettingStarted/Visualization.md
@@ -15,7 +15,7 @@ Visualization of the XTS system without actual hardware or on an HMI in producti
 
 All three visualization tools allow for marking stations to aid in following process flow during simulation, debugging and production. 
 
-By default this code will automatically use the first 10 stations defined and their `.Position` value to place markers. Stations are identified by a number that matches their index in the `MAIN.Station` array.
+By default this code will automatically use the first 10 stations and their `.Position` value to place markers. Stations are identified by a number that matches their index in the `MAIN.Station` array. However if a station's position value is 0.0 (and likely unused) it will be skipped by the station marker routine.
 
 ![XTS Visualization with stations marked](../Images/GettingStarted/Visualization-StationMarkers.png)
 ![Station definitions in code](../Images/GettingStarted/Visualization-StationCode.png)


### PR DESCRIPTION
If stations are not defined (assumed if .Position = 0.0) then skip that station when assigning the 10 default info server stations to XTS.Station[] positions.