### PR TITLE
Fix high mover count enable issue close #85

### DIFF
--- a/Base Project/Base Project.tsproj
+++ b/Base Project/Base Project.tsproj
@@ -32098,7 +32098,7 @@ External Setpoint Generation:
 		</Motion>
 		<Plc>
 			<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="PLC1" PrjFilePath="PLC1\PLC1.plcproj" TmcFilePath="PLC1\PLC1.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{729908B8-FCA7-4BA9-D747-EC0CB626B9F8}" TmcPath="PLC1\PLC1.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{380B826C-F0F3-8E16-76FE-DDB64F75007D}" TmcPath="PLC1\PLC1.tmc">
 					<Name>PLC1 Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="2" AreaNo="1">

--- a/Base Project/PLC1/PLC1.plcproj
+++ b/Base Project/PLC1/PLC1.plcproj
@@ -78,6 +78,9 @@
     <Compile Include="XTS %28Do Not Edit%29\DUTs\InternalMoverVars_typ.TcDUT">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="XTS %28Do Not Edit%29\DUTs\MotorModuleStatus_typ.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="XTS %28Do Not Edit%29\DUTs\XTSCommands_typ.TcDUT">
       <SubType>Code</SubType>
     </Compile>
@@ -424,8 +427,8 @@
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>
-  <Data>
-    <o xml:space="preserve" t="OptionKey">
+        <Data>
+          <o xml:space="preserve" t="OptionKey">
       <v n="Name">"&lt;ProjectRoot&gt;"</v>
       <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
         <v>{192FAD59-8248-4824-A8DE-9177C94C195A}</v>
@@ -2747,16 +2750,16 @@
       </d>
       <d n="Values" t="Hashtable" />
     </o>
-  </Data>
-  <TypeList>
-    <Type n="Boolean">System.Boolean</Type>
-    <Type n="Hashtable">System.Collections.Hashtable</Type>
-    <Type n="Int32">System.Int32</Type>
-    <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
-    <Type n="String">System.String</Type>
-    <Type n="UInt32">System.UInt32</Type>
-  </TypeList>
-</XmlArchive>
+        </Data>
+        <TypeList>
+          <Type n="Boolean">System.Boolean</Type>
+          <Type n="Hashtable">System.Collections.Hashtable</Type>
+          <Type n="Int32">System.Int32</Type>
+          <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
+          <Type n="String">System.String</Type>
+          <Type n="UInt32">System.UInt32</Type>
+        </TypeList>
+      </XmlArchive>
     </PlcProjectOptions>
   </ProjectExtensions>
 </Project>

--- a/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
@@ -20,6 +20,7 @@ VAR_OUTPUT
 	Error			: BOOL;			// error is currently active
 	ErrorID			: UDINT;		// errorID of the active error
 	ErrorOrigin		: STRING;		// error source, in case of errored internal function block
+	NumMovers		: USINT;		// number of movers in system
 END_VAR
 VAR
 	{attribute 'instance-path'}
@@ -34,6 +35,10 @@ VAR
 	internalEnableGroupState		: INT;
 	internalEnabled					: BOOL;
 	internalMover1Error				: BOOL;
+	
+	// implements memoization of Mediator.AllMotorModulesReady
+	// so it is only computed once per scan when needed
+	internalMotorModuleStatus		:  MotorModuleStatus_typ;
 
 	bHighDriveReady			: BOOL;
 	bControlVoltageReady	: BOOL;
@@ -60,6 +65,9 @@ VAR
 	fbGroupReset			: MC_GroupReset;
 	fbGroupStop				: MC_GroupStop;
 
+END_VAR
+VAR CONSTANT
+	ADD_TO_GROUP_SIZE		: UDINT := 30;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[]]></ST>
@@ -357,7 +365,8 @@ END_IF]]></ST>
       </Implementation>
     </Method>
     <Property Name="AllMotorModulesReady" Id="{e4a76f20-75da-0820-2f6d-be0ad375c645}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY AllMotorModulesReady : Bool]]></Declaration>
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY AllMotorModulesReady : Bool]]></Declaration>
       <Get Name="Get" Id="{f8eb48d2-a530-04d2-2b29-7da0e49d088b}">
         <Declaration><![CDATA[VAR
 	I				: UDINT;
@@ -366,25 +375,36 @@ END_IF]]></ST>
 	DriveStatusStorage: UINT;
 END_VAR]]></Declaration>
         <Implementation>
-          <ST><![CDATA[// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
-IF fbXtsEnvironment.P_IsInitialized THEN
-// Get number of parts. 
-	nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
-	IF nParts <> 0 THEN
-// Get number of modules per part and check their state
-		bHighDriveReady:= TRUE;
-		FOR I := 1 TO nParts DO 
-			nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).GetModuleCount();
-			FOR J := 1 TO nModulesInPart DO
-				DriveStatusStorage:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).ModuleTcIo(UDINT_TO_UINT(J)).GetDriveStatusValue();
-				IF NOT (DriveStatusStorage = 4135) AND NOT (fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation) THEN
-					bHighDriveReady:= FALSE;
-				END_IF 
+          <ST><![CDATA[// this is caculcation and ADS intensive so the result is memozied once per scan
+
+// only run the sum if the calc bit has not been set for this scan
+IF (NOT internalMotorModuleStatus.calcComplete) THEN
+	// Monitor DriveStatus to disallow motion commands before high drive has been achieved.
+	IF fbXtsEnvironment.P_IsInitialized THEN
+	// Get number of parts. 
+		nParts:= fbXtsEnvironment.XpuTcIo(1).GetPartCount();
+		IF nParts <> 0 THEN
+			// Get number of modules per part and check their state
+			bHighDriveReady:= TRUE;
+			FOR I := 1 TO nParts DO 
+				nModulesInPart:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).GetModuleCount();
+				FOR J := 1 TO nModulesInPart DO
+					DriveStatusStorage:= fbXtsEnvironment.XpuTcIo(1).PartTcIo(UDINT_TO_UINT(I)).ModuleTcIo(UDINT_TO_UINT(J)).GetDriveStatusValue();
+					IF NOT (DriveStatusStorage = 4135) AND NOT (fbXtsEnvironment.XpuTcIo(1).GetOperationMode() = OperationMode.Simulation) THEN
+						bHighDriveReady:= FALSE;
+					END_IF 
+				END_FOR
 			END_FOR
-		END_FOR
+		END_IF
 	END_IF
-END_IF
-AllMotorModulesReady:= bHighDriveReady;]]></ST>
+
+	// memoize the result
+	internalMotorModuleStatus.calcResult := bHighDriveReady;
+	internalMotorModuleStatus.calcComplete := TRUE;
+END_IF;
+
+// return the result
+AllMotorModulesReady:= internalMotorModuleStatus.calcResult;]]></ST>
         </Implementation>
       </Get>
     </Property>
@@ -411,6 +431,7 @@ CompleteMoverList	:= internalMoverList;]]></ST>
     <Method Name="Cyclic" Id="{f2264867-ad86-0c96-3c42-ade0fe3bf9e2}" FolderPath="Methods\">
       <Declaration><![CDATA[METHOD Cyclic : BOOL
 VAR_INPUT
+	NUM_MOVERS			: USINT;
 END_VAR
 
 VAR
@@ -442,6 +463,12 @@ VAR_INST
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// this method contains multiple state machines denoted by the headers below
+
+// update output data
+NumMovers := NUM_MOVERS;
+
+// clear memoized values for recalculation
+internalMotorModuleStatus.calcComplete := FALSE;
 
 // Handle all project cyclic calls
 
@@ -694,7 +721,7 @@ CASE internalEnableGroupState OF
 		
 		fbGroupEnable.Execute			:= TRUE;
 		
-		IF fbGroupEnable.Done THEN
+		IF fbGroupEnable.Done AND GROUP_REF.NcToPlc.CA.Common.GroupStatus.State = mcGroupStateStandby THEN
 			fbGroupEnable.Execute		:= FALSE;
 			internalEnableGroupFlag 	:= FALSE;
 			internalEnableGroupState	:= 100;
@@ -884,8 +911,39 @@ EnvironmentIsReady := nEnvironmentState >= 3;]]></ST>
         </Implementation>
       </Get>
     </Property>
+    <Property Name="GroupAddLimit" Id="{65a16f3c-a017-0638-2d93-2d84b50013fb}" FolderPath="Properties\">
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY GroupAddLimit : UDINT]]></Declaration>
+      <Get Name="Get" Id="{7d2e7f70-ceaa-0c78-163f-9558b7d4e0a1}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[// when adding movers to gropus, a smaller subset of movers should be added, not all at once
+// this returns the highest mover number that can currently be added to the group
+// based on the size of the add_to_group constant
+
+// with a size limit of 30 this will return 30, then 60, 90 etc (30 at a time, with 1-based mover array)
+// deliberate integer math is used to truncate the quotent of the group step check
+GroupAddLimit := (REAL_TO_UDINT(UDINT_TO_REAL(GROUP_REF.NcToPlc.CA.Common.GroupAxesCount)/UDINT_TO_REAL(ADD_TO_GROUP_SIZE))+1)*ADD_TO_GROUP_SIZE;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
+    <Property Name="GroupAxesCount" Id="{dec55c77-f258-0789-1555-26b4067cbe34}" FolderPath="Properties\">
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY GroupAxesCount : UDINT]]></Declaration>
+      <Get Name="Get" Id="{543f3341-ee3d-0bd4-30a4-c2f38c04ed3d}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[GroupAxesCount := GROUP_REF.NcToPlc.CA.Common.GroupAxesCount;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
     <Property Name="GroupEnabled" Id="{dca70979-fee3-0f39-3528-000ca64a8f22}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY GroupEnabled : bool]]></Declaration>
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY GroupEnabled : bool]]></Declaration>
       <Get Name="Get" Id="{a4a17b6e-a2a8-0398-0745-96cf710d270e}">
         <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
 VAR
@@ -897,7 +955,8 @@ END_VAR
       </Get>
     </Property>
     <Property Name="GroupError" Id="{3ac97d16-5fe4-0a9a-3305-6d88385b660b}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY GroupError : bool]]></Declaration>
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY GroupError : bool]]></Declaration>
       <Get Name="Get" Id="{faa6b223-287a-0e59-1c37-f312dffb5ec6}">
         <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
 VAR
@@ -933,7 +992,8 @@ END_VAR
       </Get>
     </Property>
     <Property Name="InstancePath" Id="{bb75667d-d680-0397-38c7-96136879329d}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY InstancePath : string]]></Declaration>
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY InstancePath : string]]></Declaration>
       <Get Name="Get" Id="{b9a804e4-bca0-0f1c-39b3-bb2c5353dcf1}">
         <Declaration><![CDATA[VAR
 END_VAR
@@ -944,7 +1004,8 @@ END_VAR
       </Get>
     </Property>
     <Property Name="Mover1DetectionComplete" Id="{b3d53d33-3d35-07f8-35ed-d0dbe454a97c}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY Mover1DetectionComplete : BOOL]]></Declaration>
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY Mover1DetectionComplete : BOOL]]></Declaration>
       <Get Name="Get" Id="{e92705b4-cdc3-0cc7-25dc-0275953572ce}">
         <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
 VAR
@@ -957,7 +1018,8 @@ END_VAR
       </Get>
     </Property>
     <Property Name="Mover1DetectionError" Id="{75004eac-41b5-0213-3156-b53daed26144}" FolderPath="Properties\">
-      <Declaration><![CDATA[PROPERTY Mover1DetectionError : bool]]></Declaration>
+      <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
+PROPERTY Mover1DetectionError : bool]]></Declaration>
       <Get Name="Get" Id="{e224f7d4-69bc-07c0-2d34-8a91c1a73da1}">
         <Declaration><![CDATA[{attribute 'monitoring' := 'call'}
 VAR

--- a/Base Project/PLC1/XTS (Do Not Edit)/DUTs/InternalMoverVars_typ.TcDUT
+++ b/Base Project/PLC1/XTS (Do Not Edit)/DUTs/InternalMoverVars_typ.TcDUT
@@ -72,8 +72,6 @@ STRUCT
 	lastCallValidateTrack : LREAL;
 	lastCallSetGap		: LREAL;
 	lastCallActivateTrack : LREAL;
-	
-	TestVar: BOOL;
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/Base Project/PLC1/XTS (Do Not Edit)/DUTs/MotorModuleStatus_typ.TcDUT
+++ b/Base Project/PLC1/XTS (Do Not Edit)/DUTs/MotorModuleStatus_typ.TcDUT
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.8">
+  <DUT Name="MotorModuleStatus_typ" Id="{81082df1-914c-070d-2ae8-1ed531b2762a}">
+    <Declaration><![CDATA[TYPE MotorModuleStatus_typ :
+STRUCT
+	calcComplete	: BOOL;	// calculation of motor module status complete for this scan
+	calcResult		: BOOL;	// result of calculation for this scan
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/Base Project/PLC1/XTS (Do Not Edit)/FB_XTS.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/FB_XTS.TcPOU
@@ -117,7 +117,8 @@ END_VAR
 
 END_CASE
 
-System.Cyclic();
+// call system cyclically
+System.Cyclic(NUM_MOVERS := NUM_MOVERS);
 
 // update global data
 FOR i := 1 TO NUM_MOVERS DO

--- a/Base Project/PLC1/XTS (Do Not Edit)/Objects/Mover.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Objects/Mover.TcPOU
@@ -275,21 +275,26 @@ CASE LocalVars.State OF
 		Error	:= FALSE;
 		ErrorID	:= 0;
 		
-		LocalVars.fbAddToGroup.Execute			:= TRUE;
+		// add to group is done in batches controlled by the mediator
+		LocalVars.fbAddToGroup.Execute			:= LocalVars.MoverIndex <= Mediator.GroupAddLimit;
 		LocalVars.fbAddToGroup.IdentInGroup		:= UDINT_TO_IDENTINGROUP( AxisReference.NcToPlc.AxisId - 1 );
 		
-		IF LocalVars.fbAddToGroup.Done THEN
+		// wait for done and secondary check of number of movers (fb may report done before NC is done with high mover counts)
+		IF LocalVars.fbAddToGroup.Done AND Mediator.GroupAxesCount = Mediator.NumMovers THEN
+			// all axes added to group, move to next state
 			InGroup						:= TRUE;
 			IdentInGroup				:= AxisReference.NcToPlc.AxisId - 1;
 			LocalVars.fbAddToGroup.Execute		:= FALSE;
-			
-			Mediator.EnableGroup();
 			LocalVars.State				:= MV_ENABLEGROUP;
 		ELSIF LocalVars.fbAddToGroup.Error THEN
+			// error with add to group fb
+			LocalVars.fbAddToGroup.Execute		:= FALSE;
 			ErrorID						:= LocalVars.fbAddToGroup.ErrorId;
 			ErrorOrigin					:= CONCAT( InstancePath, '.fbAddToGroup' );
 			LocalVars.State				:= MV_ERROR;
 		ELSIF AxisReference.Status.Error THEN
+			// error reported by the axis
+			LocalVars.fbAddToGroup.Execute		:= FALSE;
 			ErrorID					:= AxisReference.Status.ErrorID;
 			ErrorOrigin				:= Concat(InstancePath, ': General NC Error during add to group');
 			LocalVars.State			:= MV_ERROR;
@@ -297,7 +302,6 @@ CASE LocalVars.State OF
 		
 	MV_ENABLEGROUP:	// ----------------------------------------------- have mediator enable group
 		Mediator.EnableGroup();
-		LocalVars.TestVar:= Mediator.AllMotorModulesReady;
 		IF Mediator.GroupEnabled AND Mediator.AllMotorModulesReady THEN
 			LocalVars.State := MV_RUN;
 		ELSIF Mediator.Error THEN


### PR DESCRIPTION
With high mover counts (~60+) several issues were observed:
- The XTS enable sequence would not complete successfully with movers all going into fault as well as the group
- During the add to group and enable group portions of the enable sequence several PLC scan time overruns were observed. In some cases 16ms scans were observed when a 2ms tick was configured

The following changes were implemented:
- Movers are added to the group in batches of 30
- When adding movers to the group the mover state machine no longer tries to enable the group upon receiving the .Done bit for the add to group FB. It also waits for the CA group mover count (via GROUP_REF) to equal the number of movers thus eliminating the possibility of trying to enable the group while higher numbered movers are still being added.
- When the mover state machine enabling the group, calls were made to Mediator.AllMotorModulesReady. This method would query all motor modules for each mover, on every scan and was the source of the overruns. The get for the AllMotorModulesReady property now makes use of memoization and will only query each motor module on the first call to the property. Subsequent calls to the property on the same scan simply return the previously computed sum.