### PR TITLE
Fix issue with muting an empty position trigger

### DIFF
--- a/Base Project/Base Project.tsproj
+++ b/Base Project/Base Project.tsproj
@@ -32098,7 +32098,7 @@ External Setpoint Generation:
 		</Motion>
 		<Plc>
 			<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="PLC1" PrjFilePath="PLC1\PLC1.plcproj" TmcFilePath="PLC1\PLC1.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{380B826C-F0F3-8E16-76FE-DDB64F75007D}" TmcPath="PLC1\PLC1.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{33016FF4-780D-6A14-A50C-09EC1C49CD8A}" TmcPath="PLC1\PLC1.tmc">
 					<Name>PLC1 Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="2" AreaNo="1">

--- a/Base Project/PLC1/XTS (Do Not Edit)/Objects/PositionTrigger.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Objects/PositionTrigger.TcPOU
@@ -212,7 +212,7 @@ END_VAR
       <Implementation>
         <ST><![CDATA[// message for debugging as this function is typically called when acting on a position trigger
 newCallTime		:= ULINT_TO_LREAL(F_GetSystemTime())/1E7;
-IF ( newCallTime - lastCallMuteCurrent ) > 1 THEN
+IF ( newCallTime - lastCallMuteCurrent ) > 1 AND internalCurrentMover <> 0 THEN
 	MsgCreate.CreateEx( TC_EVENTS.XtsBaseEventClass.PositionTriggerMuteCurrent,0 );
 	MsgCreate.ipArguments.Clear().AddString(THIS^.InstancePath).AddUDint(internalCurrentMover^.IdentInGroup);
 	MsgCreate.Send(0);


### PR DESCRIPTION
When calling PositionTrigger.MuteCurrent() on a position trigger without a current mover the messaging code would fault for a null reference. This fix checks for a current mover before posting a message.