### PR TITLE
Unify MoverList.LogicalX methods with iMoverList return type

### DIFF
--- a/Base Project/PLC1/XTS (Do Not Edit)/ITFs/iMoverList.TcIO
+++ b/Base Project/PLC1/XTS (Do Not Edit)/ITFs/iMoverList.TcIO
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.13">
   <Itf Name="iMoverList" Id="{9cc4a2ad-2506-4bdd-acf3-bfbfde25ab77}">
     <Declaration><![CDATA[INTERFACE iMoverList]]></Declaration>
     <Folder Name="Methods" Id="{82f0078e-13af-0a56-283e-d65bfe6ce910}" />
@@ -92,36 +92,29 @@ END_VAR
         <Declaration><![CDATA[]]></Declaration>
       </Get>
     </Property>
-    <Method Name="LogicalComplement" Id="{99897a70-e30e-0da3-0186-cef07523538c}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalComplement : MoverList
-VAR_INPUT
-END_VAR
-
-]]></Declaration>
-    </Method>
     <Method Name="LogicalDifference" Id="{28dd98c9-5c2b-06ab-24f3-3fbd8540614a}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalDifference : MoverList
+      <Declaration><![CDATA[METHOD LogicalDifference : iMoverList
 VAR_INPUT
 	
-	MoverList		: MoverList;
+	MoverList		: REFERENCE TO MoverList;
 
 END_VAR
 ]]></Declaration>
     </Method>
     <Method Name="LogicalIntersect" Id="{044089b7-d05a-06ed-1b08-0d7870b3db96}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalIntersect : MoverList
+      <Declaration><![CDATA[METHOD LogicalIntersect : IMoverList
 VAR_INPUT
 	
-	MoverList		: MoverList;
+	MoverList		: REFERENCE TO MoverList;
 
 END_VAR
 ]]></Declaration>
     </Method>
     <Method Name="LogicalUnion" Id="{a80cf7c9-101b-0ad9-0af0-3ff72543790d}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalUnion : MoverList
+      <Declaration><![CDATA[METHOD LogicalUnion : IMoverList
 VAR_INPUT
 	
-	MoverList		: MoverList;
+	MoverList		: REFERENCE TO MoverList;
 
 END_VAR
 ]]></Declaration>

--- a/Base Project/PLC1/XTS (Do Not Edit)/Objects/MoverList.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Objects/MoverList.TcPOU
@@ -544,31 +544,11 @@ END_FOR]]></ST>
         </Implementation>
       </Get>
     </Property>
-    <Method Name="LogicalComplement" Id="{d6bb64e7-1c08-0ac2-2a32-42be336ae034}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalComplement : MoverList
-VAR_INPUT
-END_VAR
-
-VAR
-	i: UINT;
-END_VAR]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[
-
-FOR i := 1 TO Param.MAX_MOVERS DO
-	
-	IF NOT THIS^.Contains( Mediator.MoverArray[i]^ ) THEN
-		LogicalComplement.RegisterMover( Mediator.MoverArray[i]^ );
-	END_IF
-
-END_FOR]]></ST>
-      </Implementation>
-    </Method>
     <Method Name="LogicalDifference" Id="{a0c51d7c-09ca-0254-378e-53c1775ec0b5}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalDifference : MoverList
+      <Declaration><![CDATA[METHOD LogicalDifference : iMoverList
 VAR_INPUT
 	
-	MoverList		: MoverList;
+	MoverList		: REFERENCE TO MoverList;
 
 END_VAR
 VAR
@@ -576,23 +556,30 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
+        <ST><![CDATA[// filters this mover list by removing items from the provided mover list
+FOR i := 1 TO SIZEOF(internalRegisteredMovers) / SIZEOF(internalRegisteredMovers[1]) DO
 
-
-FOR i := 1 TO Param.MAX_MOVERS DO
-	
-	IF (NOT MoverList.Contains(internalRegisteredMovers[i]^ )) THEN
-		LogicalDifference.RegisterMover( internalRegisteredMovers[i]^ );
+	// test for valid mover
+    IF internalRegisteredMovers[i] <> 0 THEN
+		// test for mover in provided list (then unregister from this list)
+		IF MoverList.Contains(internalRegisteredMovers[i]^) THEN
+			// unregister this mover, the manual way
+				internalRegisteredMovers[i]  := 0; // remove the pointer
+                internalRegisteredMoverCount := internalRegisteredMoverCount - 1;
+		END_IF
 	END_IF
+	
+END_FOR;
 
-END_FOR]]></ST>
+// return this list for chaining
+LogicalDifference := THIS^;]]></ST>
       </Implementation>
     </Method>
     <Method Name="LogicalIntersect" Id="{83ddeada-4967-0249-0f08-a02d5e1843f1}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalIntersect : MoverList
+      <Declaration><![CDATA[METHOD LogicalIntersect : iMoverList
 VAR_INPUT
 	
-	MoverList		: MoverList;
+	MoverList		: REFERENCE TO MoverList;
 
 END_VAR
 
@@ -600,31 +587,40 @@ VAR
 	i				: UINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
+        <ST><![CDATA[// filters this mover list by removing items from the provided mover list
+FOR i := 1 TO SIZEOF(internalRegisteredMovers) / SIZEOF(internalRegisteredMovers[1]) DO
 
-FOR i := 1 TO Param.MAX_MOVERS DO
-	
-	IF MoverList.Contains( Mediator.MoverArray[i]^ ) AND THIS^.Contains( Mediator.MoverArray[i]^ ) THEN
-		LogicalIntersect.RegisterMover( Mediator.MoverArray[i]^ );	
+	// test for valid mover
+    IF internalRegisteredMovers[i] <> 0 THEN
+		// test for a mover not in the provided list (then remove from this list)
+		IF NOT MoverList.Contains(internalRegisteredMovers[i]^) THEN
+			// unregister this mover, the manual way
+				internalRegisteredMovers[i]  := 0; // remove the pointer
+                internalRegisteredMoverCount := internalRegisteredMoverCount - 1;
+		END_IF
 	END_IF
 	
-END_FOR]]></ST>
+END_FOR;
+
+// return this list for chaining
+LogicalIntersect := THIS^;]]></ST>
       </Implementation>
     </Method>
     <Method Name="LogicalUnion" Id="{328a0d90-4052-09a0-1fd6-2c3bd426e573}" FolderPath="Methods\">
-      <Declaration><![CDATA[METHOD LogicalUnion : MoverList
+      <Declaration><![CDATA[METHOD LogicalUnion : iMoverList
 VAR_INPUT
 	
-	MoverList		: MoverList;
+	MoverList		: REFERENCE TO MoverList;
 
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[
+// cobmine the two lists by adding the provided list to this one
+// the register function de-duplicates
+THIS^.RegisterMoverList( MoverList );
 
-LogicalUnion.RegisterMoverList( MoverList );
-LogicalUnion.RegisterMoverList( THIS^ );
-]]></ST>
+LogicalUnion := THIS^;]]></ST>
       </Implementation>
     </Method>
     <Method Name="MoveAllToPosition" Id="{bd912cae-8475-45f4-9366-6d4e3f45dbfd}" FolderPath="Methods\">

--- a/Base Project/PLC1/XTS (Do Not Edit)/Objects/MoverList.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Objects/MoverList.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.13">
   <POU Name="MoverList" Id="{6a6492c3-5dac-4c49-8708-8eab34cf4a1d}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK MoverList EXTENDS Objective IMPLEMENTS iMoverList
 VAR_INPUT
@@ -581,8 +581,8 @@ END_VAR
 
 FOR i := 1 TO Param.MAX_MOVERS DO
 	
-	IF THIS^.Contains( Mediator.MoverArray[i]^ ) AND NOT MoverList.Contains( Mediator.MoverArray[i]^ ) THEN
-		LogicalDifference.RegisterMover( Mediator.MoverArray[i]^ );
+	IF (NOT MoverList.Contains(internalRegisteredMovers[i]^ )) THEN
+		LogicalDifference.RegisterMover( internalRegisteredMovers[i]^ );
 	END_IF
 
 END_FOR]]></ST>

--- a/Documentation/docs/CodeReference/Objects/MoverList.md
+++ b/Documentation/docs/CodeReference/Objects/MoverList.md
@@ -142,16 +142,8 @@ MoverListA.GetMoverByLocation( 3, 3000, MC_Negative_Direction ).SetAcceleration(
 
 ### LogicalComplement
 
-*LogicalComplement()*
-
-> Returns the logical complement of the current MoverList. Thus the returned list will list all movers not in the current MoverList.
-
-```javascript
-// System contains: M1, M2, M3, M4, M5
-// MoverListA =     M1, M2, M3
-MoverListA.LogicalCompliment(); // returns: M4, M5
-```
-
+!!! Removed
+	This method has been removed to help with better code readability and to make the LogicalXXX methods work with the same parameter signatures. The same functionality can be achieved with the use of [LogicalDifference](#logicaldifference): `MoverListA.LogicalDifference(XTS.System.CompleteMoverList)`.
 
 ### LogicalDifference
 


### PR DESCRIPTION
The LogicalX functions attached to a mover list would return mover lists themselves, not iMoverList which is the convention elsewhere in code (or returning iMover) and was thus not chainable. This resolves this issue. Also resolved was LogicalDifference not returning the correct difference of 2 lists.

Finally, `MoverList.LogicalCompliment()` was removed. The proposed updated documentation explains the reasoning

<img width="787" height="210" alt="image" src="https://github.com/user-attachments/assets/beb3735e-b352-4ddc-91d4-b6f071dc7633" />
