### PR TITLE
Bug/list counts

### DIFF
--- a/Base Project/Base Project.tsproj
+++ b/Base Project/Base Project.tsproj
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4026.21">
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4026.24">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{C929B002-BF94-48A2-937B-5D20DED8EF3B}">OperationMode</Name>
@@ -4021,7 +4021,7 @@ and will return to Group State Standby when the situation permits.
 			<SubItem>
 				<Name>AllAxesStanding</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-				<Comment><![CDATA[Indicate whether all axes are physically standing, i.e. velocity and acceleration are zero. This definition differs from the definition of the GroupStateMoving, which indicates whether a Motion Command is currently active.]]></Comment>
+				<Comment><![CDATA[Indicates whether all axes are physically standing, i.e. velocity and acceleration are zero. This definition differs from the definition of the GroupStateMoving, which indicates whether a Motion Command is currently active.]]></Comment>
 				<BitSize>1</BitSize>
 				<BitOffs>1</BitOffs>
 			</SubItem>
@@ -4230,7 +4230,7 @@ and will return to Group State Standby when the situation permits.
 			</SubItem>
 		</DataType>
 		<DataType>
-			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -4440,7 +4440,7 @@ and will return to Group State Standby when the situation permits.
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
+			<Name GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>OpModePosAreaMonitoring</Name>
@@ -4558,7 +4558,7 @@ and will return to Group State Standby when the situation permits.
 			</SubItem>
 		</DataType>
 		<DataType>
-			<Name GUID="{303D9411-849C-467F-8A4C-5C8CD0F3DD46}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE2_FLAGS</Name>
+			<Name GUID="{303D9411-849C-467F-8A4C-5C8CD0F3DD46}" Namespace="MC" HideType="true">NCTOPLC_AXIS_REF_STATE2_FLAGS</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>AvoidingCollision</Name>
@@ -4577,7 +4577,7 @@ and will return to Group State Standby when the situation permits.
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{669F3788-48FD-42CF-8A59-2DA946853FB6}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE2</Name>
+			<Name GUID="{669F3788-48FD-42CF-8A59-2DA946853FB6}" Namespace="MC" HideType="true">NCTOPLC_AXIS_REF_STATE2</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Value</Name>
@@ -4602,7 +4602,7 @@ and will return to Group State Standby when the situation permits.
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3_FLAGS</Name>
+			<Name GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC" HideType="true">NCTOPLC_AXIS_REF_STATE3_FLAGS</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>TouchProbe1InputState</Name>
@@ -4627,7 +4627,7 @@ and will return to Group State Standby when the situation permits.
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3</Name>
+			<Name GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC" HideType="true">NCTOPLC_AXIS_REF_STATE3</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Value</Name>
@@ -4652,7 +4652,7 @@ and will return to Group State Standby when the situation permits.
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Name>
+			<Name GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC" HideType="true">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Name>
 			<BitSize>8</BitSize>
 			<SubItem>
 				<Name>CamActivationPending</Name>
@@ -5054,19 +5054,14 @@ External Setpoint Generation:
 				<BitOffs>0</BitOffs>
 			</SubItem>
 			<SubItem>
-				<Name>Dxd</Name>
+				<Name HideItem="true">Dxd</Name>
 				<Type GUID="{762962EF-0BB3-42E3-80C3-82A3958BB33D}" Namespace="MC">CDT_PLCTOMC_GROUP_CM</Type>
 				<BitSize>1024</BitSize>
 				<BitOffs>0</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_hide</Name>
-					</Property>
-				</Properties>
 			</SubItem>
 		</DataType>
 		<DataType>
-			<Name GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">PLCTONC_AXIS_REF_CTRL</Name>
+			<Name GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC" HideType="true" IecDeclaration="DWORD;">PLCTONC_AXIS_REF_CTRL</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Enable</Name>
@@ -5272,7 +5267,7 @@ External Setpoint Generation:
 		<ImageData Id="1015">424d360400000000000036000000280000001000000010000000010020000000000000000000c30e0000c30e000000000000000000009393930093939300939393009393930093939300939393009393930093939300939393009393930093939300939393009393930093939300939393009393930093939300d5d4d400d2d0d000cfcdcd00cbc9c900c8c6c600c5c3c300c2bfbf00bebcbc00bbb8b800b8b5b500b4b2b200b1aeae00aeabab00aaa7a7009393930093939300d9d7d700d5d4d400d2d0d000cfcdcd00cbc9c900c8c6c600c5c3c300c2bfbf00bebcbc00bbb8b800b8b5b500b4b2b200b1aeae00aeabab009393930093939300dcdbdb00d9d7d700d5d4d400d2d0d000cfcdcd00cccaca00c8c6c600c5c3c300c2bfbf0084838300918f8f00b8b5b500b4b2b200b1aeae009393930093939300dfdede00dcdbdb00d9d7d700d5d4d4006189e9000852fd006289e500c8c6c600c5c3c300aba9a9005050500071707000b6b3b300b4b2b2009393930093939300e3e1e1008f8f8f004040400040404000034df800004dff00044cf40040404000404040004040400040404000404040007e7d7d00b8b5b5009393930093939300e6e5e500e3e1e100dfdede00dcdbdb00678eec000b54fd00688ee800cfcdcd00cbc9c900b0aeae005151510074727200bcbaba00bbb8b8009393930093939300e9e8e800e6e5e500e3e1e100dfdede00d7d7d9004d73ca00d1d2d400d2d0d000cfcdcd008b8a8a009a989800c5c3c300c2bfbf00bebcbc009393930093939300edecec00e9e8e800e6e5e500e3e1e100436dcd00004dff00436ccc00d5d4d400d2d0d000cfcdcd00cbc9c900c8c6c600c5c3c300c2bfbf009393930093939300f0efef00edecec00e9e8e8007c94cd000d50ec00004dff000e50ea00708ac700d5d4d400d2d0d000cfcdcd00cbc9c900c8c6c600c5c3c3009393930093939300eeeded00f0efef00edecec00597cce00a6b3d400004dff00a1aecf005578ca00d9d7d700d5d4d400d2d0d000cfcdcd00cccaca00c8c6c6009393930093939300ecebeb00eeeded00f0efef00edecec00e9e8e800004dff00e3e1e100dfdede00dcdbdb00d9d7d700d5d4d400d2d0d000cfcdcd00cbc9c9009393930093939300ebe9e900ecebeb00eeeded00f0efef00edecec00004dff00e6e5e500e3e1e100dfdede00dcdbdb00d9d7d700d5d4d400d2d0d000cfcdcd009393930093939300e9e7e700ebe9e900ecebeb00eeeded00f0efef00004dff00e9e8e800e6e5e500e3e1e100dfdede00dcdbdb00d9d7d700d5d4d400d2d0d0009393930093939300e7e5e500e9e7e700ebe9e900ecebeb00eeeded00f0efef00edecec00e9e8e800e6e5e500e3e1e100dfdede00dcdbdb00d9d7d700d5d4d4009393930093939300939393009393930093939300939393009393930093939300939393009393930093939300939393009393930093939300939393009393930093939300</ImageData>
 		<ImageData Id="1016">424dd6020000000000003600000028000000100000000e0000000100180000000000a0020000130b0000130b00000000000000000000ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff8e8582b1a9a5ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffc3bebbaea9a659565355524f5755525a58555e5b5862605d6764616d6a6772706d817f7cff00ffff00ffff00ffff00ff7e7875e1dddca1a09e7673707b7875817f7c817f7d85838084827f84817e827e7c52504d777472ff00ffff00ffff00ff4845428b89886a686b7c78769693909a979599959398969497969395918f73706e5e5b595e5b58acaaa7ff00ffff00ff45423f53504d94908dff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff7e7a7764625f989693ff00ffff00ff474441534f4ca5a19eff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff9793915f5c59989592ff00ffff00ff524e4b4d4a484f4d4aff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff565451625f5caaa8a5ff00ffff00ffff00ff464442504e4b55535054524f5653505755525755525655515554515a58555b5956726f6cff00ffff00ffff00ffff00ffff00ff5653504443404946434a48454c49474e4b484e4b49504e4b514e4b757370ff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ffff00ff</ImageData>
 	</ImageDatas>
-	<Project ProjectGUID="{E3FDD453-7143-4CBE-AF2D-E7E762464CFC}" TargetNetId="10.200.166.141.1.1" Target64Bit="true" ShowHideConfigurations="#x106">
+	<Project ProjectGUID="{E3FDD453-7143-4CBE-AF2D-E7E762464CFC}" Target64Bit="true" ShowHideConfigurations="#x106">
 		<System>
 			<Settings MaxCpus="8" NonWinCpus="4" RouterMemory="1073741824" MaxStackSize="256">
 				<Cpu CpuId="6" BaseTime="2500"/>
@@ -9269,7 +9264,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>71</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -9277,91 +9272,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>73</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>75</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>77</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>79</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>81</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>83</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>85</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>87</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>89</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>91</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>93</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>95</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>97</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>99</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>101</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -9369,7 +9364,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>71</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -9377,91 +9372,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>73</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>75</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>77</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>79</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>81</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>83</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>85</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>87</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>89</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>91</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>93</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>95</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>97</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>99</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>101</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -9470,193 +9465,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>105</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>107</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>109</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>111</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>113</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>115</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>117</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>119</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>121</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>123</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>125</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>127</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>129</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>131</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>133</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>135</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>137</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>139</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>141</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>143</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>145</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>147</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>149</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>151</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>153</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>155</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>157</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>159</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>161</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>163</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>165</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>167</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -10538,7 +10533,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>169</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -10546,91 +10541,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>171</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>173</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>175</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>177</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>179</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>181</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>183</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>185</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>187</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>189</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>191</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>193</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>195</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>197</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>199</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -10638,7 +10633,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>169</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -10646,91 +10641,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>171</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>173</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>175</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>177</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>179</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>181</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>183</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>185</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>187</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>189</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>191</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>193</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>195</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>197</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>199</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -10739,193 +10734,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>203</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>205</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>207</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>209</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>211</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>213</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>215</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>217</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>219</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>221</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>223</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>225</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>227</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>229</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>231</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>233</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>235</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>237</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>239</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>241</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>243</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>245</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>247</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>249</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>251</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>253</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>255</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>257</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>259</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>261</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>263</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>265</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -11807,7 +11802,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>267</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -11815,91 +11810,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>269</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>271</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>273</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>275</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>277</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>279</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>281</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>283</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>285</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>287</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>289</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>291</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>293</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>295</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>297</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -11907,7 +11902,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>267</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -11915,91 +11910,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>269</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>271</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>273</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>275</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>277</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>279</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>281</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>283</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>285</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>287</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>289</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>291</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>293</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>295</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>297</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -12008,193 +12003,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>301</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>303</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>305</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>307</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>309</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>311</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>313</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>315</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>317</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>319</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>321</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>323</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>325</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>327</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>329</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>331</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>333</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>335</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>337</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>339</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>341</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>343</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>345</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>347</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>349</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>351</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>353</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>355</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>357</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>359</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>361</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>363</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -13076,7 +13071,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>365</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -13084,91 +13079,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>367</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>369</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>371</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>373</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>375</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>377</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>379</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>381</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>383</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>385</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>387</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>389</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>391</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>393</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>395</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -13176,7 +13171,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>365</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -13184,91 +13179,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>367</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>369</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>371</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>373</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>375</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>377</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>379</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>381</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>383</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>385</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>387</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>389</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>391</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>393</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>395</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -13277,193 +13272,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>399</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>401</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>403</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>405</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>407</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>409</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>411</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>413</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>415</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>417</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>419</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>421</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>423</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>425</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>427</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>429</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>431</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>433</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>435</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>437</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>439</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>441</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>443</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>445</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>447</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>449</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>451</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>453</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>455</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>457</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>459</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>461</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -14345,7 +14340,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>463</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -14353,91 +14348,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>465</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>467</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>469</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>471</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>473</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>475</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>477</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>479</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>481</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>483</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>485</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>487</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>489</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>491</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>493</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -14445,7 +14440,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>463</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -14453,91 +14448,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>465</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>467</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>469</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>471</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>473</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>475</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>477</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>479</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>481</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>483</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>485</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>487</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>489</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>491</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>493</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -14546,193 +14541,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>497</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>499</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>501</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>503</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>505</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>507</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>509</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>511</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>513</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>515</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>517</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>519</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>521</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>523</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>525</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>527</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>529</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>531</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>533</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>535</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>537</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>539</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>541</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>543</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>545</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>547</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>549</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>551</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>553</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>555</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>557</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>559</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -15614,7 +15609,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>561</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -15622,91 +15617,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>563</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>565</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>567</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>569</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>571</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>573</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>575</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>577</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>579</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>581</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>583</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>585</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>587</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>589</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>591</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -15714,7 +15709,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>561</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -15722,91 +15717,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>563</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>565</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>567</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>569</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>571</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>573</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>575</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>577</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>579</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>581</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>583</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>585</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>587</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>589</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>591</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -15815,193 +15810,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>595</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>597</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>599</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>601</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>603</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>605</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>607</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>609</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>611</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>613</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>615</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>617</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>619</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>621</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>623</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>625</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>627</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>629</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>631</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>633</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>635</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>637</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>639</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>641</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>643</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>645</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>647</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>649</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>651</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>653</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>655</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>657</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -16883,7 +16878,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>659</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -16891,91 +16886,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>661</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>663</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>665</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>667</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>669</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>671</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>673</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>675</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>677</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>679</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>681</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>683</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>685</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>687</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>689</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -16983,7 +16978,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>659</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -16991,91 +16986,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>661</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>663</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>665</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>667</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>669</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>671</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>673</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>675</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>677</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>679</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>681</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>683</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>685</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>687</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>689</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -17084,193 +17079,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>693</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>695</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>697</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>699</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>701</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>703</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>705</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>707</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>709</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>711</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>713</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>715</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>717</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>719</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>721</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>723</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>725</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>727</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>729</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>731</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>733</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>735</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>737</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>739</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>741</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>743</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>745</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>747</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>749</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>751</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>753</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>755</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -18152,7 +18147,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>757</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -18160,91 +18155,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>759</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>761</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>763</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>765</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>767</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>769</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>771</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>773</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>775</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>777</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>779</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>781</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>783</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>785</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>787</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -18252,7 +18247,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040010</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>757</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -18260,91 +18255,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>759</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>761</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>763</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>765</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>767</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>769</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>771</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>773</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>775</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>777</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>779</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>781</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>783</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>785</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>787</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -18353,193 +18348,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>791</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>793</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>795</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>797</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>799</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>801</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>803</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>805</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>807</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>809</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>811</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>813</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>815</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>817</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>819</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>821</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>823</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>825</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>827</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>829</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>831</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>833</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>835</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>837</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>839</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>841</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>843</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>845</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>847</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>849</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>851</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040010</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>853</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -19748,7 +19743,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>71</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -19756,91 +19751,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>73</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>75</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>77</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>79</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>81</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>83</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>85</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>87</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>89</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>91</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>93</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>95</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>97</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>99</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>101</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -19848,7 +19843,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>71</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -19856,91 +19851,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>73</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>75</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>77</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>79</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>81</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>83</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>85</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>87</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>89</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>91</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>93</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>95</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>97</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>99</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>101</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -19949,193 +19944,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>105</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>107</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>109</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>111</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>113</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>115</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>117</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>119</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>121</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>123</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>125</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>127</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>129</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>131</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>133</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>135</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>137</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>139</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>141</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>143</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>145</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>147</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>149</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>151</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>153</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>155</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>157</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>159</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>161</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>163</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>165</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>167</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -21017,7 +21012,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>169</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -21025,91 +21020,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>171</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>173</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>175</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>177</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>179</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>181</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>183</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>185</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>187</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>189</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>191</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>193</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>195</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>197</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>199</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -21117,7 +21112,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>169</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -21125,91 +21120,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>171</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>173</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>175</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>177</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>179</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>181</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>183</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>185</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>187</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>189</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>191</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>193</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>195</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>197</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>199</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -21218,193 +21213,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>203</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>205</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>207</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>209</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>211</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>213</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>215</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>217</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>219</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>221</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>223</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>225</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>227</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>229</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>231</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>233</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>235</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>237</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>239</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>241</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>243</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>245</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>247</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>249</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>251</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>253</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>255</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>257</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>259</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>261</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>263</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>265</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -22286,7 +22281,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>267</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -22294,91 +22289,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>269</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>271</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>273</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>275</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>277</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>279</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>281</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>283</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>285</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>287</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>289</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>291</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>293</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>295</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>297</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -22386,7 +22381,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>267</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -22394,91 +22389,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>269</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>271</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>273</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>275</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>277</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>279</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>281</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>283</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>285</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>287</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>289</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>291</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>293</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>295</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>297</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -22487,193 +22482,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>301</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>303</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>305</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>307</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>309</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>311</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>313</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>315</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>317</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>319</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>321</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>323</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>325</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>327</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>329</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>331</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>333</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>335</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>337</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>339</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>341</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>343</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>345</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>347</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>349</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>351</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>353</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>355</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>357</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>359</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>361</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>363</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -23555,7 +23550,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>365</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -23563,91 +23558,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>367</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>369</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>371</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>373</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>375</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>377</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>379</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>381</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>383</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>385</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>387</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>389</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>391</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>393</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>395</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -23655,7 +23650,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>365</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -23663,91 +23658,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>367</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>369</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>371</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>373</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>375</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>377</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>379</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>381</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>383</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>385</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>387</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>389</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>391</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>393</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>395</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -23756,193 +23751,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>399</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>401</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>403</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>405</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>407</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>409</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>411</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>413</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>415</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>417</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>419</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>421</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>423</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>425</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>427</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>429</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>431</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>433</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>435</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>437</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>439</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>441</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>443</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>445</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>447</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>449</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>451</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>453</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>455</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>457</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>459</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>461</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -24824,7 +24819,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>463</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -24832,91 +24827,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>465</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>467</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>469</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>471</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>473</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>475</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>477</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>479</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>481</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>483</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>485</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>487</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>489</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>491</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>493</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -24924,7 +24919,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>463</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -24932,91 +24927,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>465</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>467</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>469</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>471</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>473</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>475</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>477</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>479</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>481</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>483</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>485</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>487</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>489</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>491</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>493</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -25025,193 +25020,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>497</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>499</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>501</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>503</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>505</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>507</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>509</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>511</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>513</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>515</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>517</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>519</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>521</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>523</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>525</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>527</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>529</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>531</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>533</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>535</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>537</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>539</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>541</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>543</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>545</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>547</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>549</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>551</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>553</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>555</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>557</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>559</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -26093,7 +26088,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>561</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -26101,91 +26096,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>563</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>565</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>567</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>569</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>571</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>573</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>575</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>577</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>579</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>581</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>583</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>585</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>587</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>589</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>591</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -26193,7 +26188,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>561</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -26201,91 +26196,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>563</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>565</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>567</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>569</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>571</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>573</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>575</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>577</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>579</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>581</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>583</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>585</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>587</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>589</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>591</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -26294,193 +26289,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>595</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>597</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>599</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>601</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>603</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>605</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>607</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>609</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>611</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>613</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>615</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>617</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>619</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>621</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>623</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>625</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>627</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>629</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>631</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>633</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>635</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>637</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>639</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>641</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>643</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>645</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>647</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>649</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>651</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>653</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>655</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>657</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -27362,7 +27357,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>659</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -27370,91 +27365,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>661</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>663</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>665</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>667</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>669</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>671</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>673</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>675</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>677</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>679</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>681</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>683</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>685</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>687</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>689</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -27462,7 +27457,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>659</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -27470,91 +27465,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>661</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>663</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>665</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>667</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>669</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>671</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>673</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>675</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>677</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>679</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>681</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>683</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>685</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>687</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>689</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -27563,193 +27558,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>693</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>695</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>697</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>699</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>701</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>703</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>705</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>707</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>709</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>711</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>713</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>715</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>717</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>719</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>721</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>723</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>725</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>727</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>729</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>731</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>733</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>735</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>737</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>739</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>741</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>743</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>745</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>747</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>749</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>751</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>753</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>755</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -28631,7 +28626,7 @@ External Setpoint Generation:
 										<Name>Control</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>1</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>757</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -28639,91 +28634,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>759</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>761</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>763</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>765</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>767</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>769</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>771</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>773</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>775</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>777</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>779</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>781</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>783</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>785</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>1</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>787</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -28731,7 +28726,7 @@ External Setpoint Generation:
 										<Name>Status</Name>
 										<OTCID>#x03040030</OTCID>
 										<AreaNo>0</AreaNo>
-										<ByteOffs>0</ByteOffs>
+										<ByteOffs>757</ByteOffs>
 										<ByteSize>2</ByteSize>
 									</Value>
 									<Value>
@@ -28739,91 +28734,91 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>759</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>761</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>763</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>765</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>767</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>769</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>771</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>773</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>775</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>777</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>779</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>781</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>783</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>785</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>787</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -28832,193 +28827,193 @@ External Setpoint Generation:
 										<Data ArrayIndex="0">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>791</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="1">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>793</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="2">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>795</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="3">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>797</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="4">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>799</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="5">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>801</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="6">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>803</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="7">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>805</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="8">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>807</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="9">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>809</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="10">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>811</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="11">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>813</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="12">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>815</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="13">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>817</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="14">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>819</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="15">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>821</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="16">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>823</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="17">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>825</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="18">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>827</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="19">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>829</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="20">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>831</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="21">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>833</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="22">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>835</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="23">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>837</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="24">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>839</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="25">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>841</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="26">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>843</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="27">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>845</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="28">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>847</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="29">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>849</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="30">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>851</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 										<Data ArrayIndex="31">
 											<OTCID>#x03040030</OTCID>
 											<AreaNo>0</AreaNo>
-											<ByteOffs>0</ByteOffs>
+											<ByteOffs>853</ByteOffs>
 											<ByteSize>2</ByteSize>
 										</Data>
 									</Value>
@@ -39742,7 +39737,7 @@ External Setpoint Generation:
 		</System>
 		<Motion>
 			<NC>
-				<SafTask Priority="8" CycleTime="20000" AmsPort="501" Affinity="#x00000080" IoAtBegin="true" AmsNetId="10.200.166.137.1.1" SafTaskInfo="256">
+				<SafTask Priority="8" CycleTime="20000" AmsPort="501" Affinity="#x00000080" IoAtBegin="true" SafTaskInfo="256">
 					<Name>NC SAF</Name>
 					<Vars VarGrpType="1" InsertType="1">
 						<Name>Inputs</Name>
@@ -39763,6 +39758,86 @@ External Setpoint Generation:
 				<Axis File="Mover Axis 4.xti" Id="4"/>
 				<Axis File="Mover Axis 5.xti" Id="5"/>
 				<Axis File="Mover Axis 6.xti" Id="6"/>
+				<Instance Id="#x05000100" KeepUnrestoredLinks="2">
+					<Name>Mc-Instance for NcPtp</Name>
+					<ImageId>4</ImageId>
+					<TmcDesc GUID="{6445FBA6-B920-4AD2-873B-8C61DD652099}">
+						<Name>MC Instance Unversioned</Name>
+						<CLSID ClassFactory="TcNc3">{05030084-0000-0000-F000-000000000064}</CLSID>
+						<InitSequence>PSO</InitSequence>
+						<Contexts>
+							<Context>
+								<Id>0</Id>
+								<Name>MET</Name>
+							</Context>
+							<Context>
+								<Id>1</Id>
+								<Name>MPT</Name>
+							</Context>
+							<Context>
+								<Id>3</Id>
+								<Name>MJT</Name>
+							</Context>
+						</Contexts>
+						<Parameters>
+							<Parameter ReadOnly="true">
+								<Name>Execution-Task OID (MET)</Name>
+								<Comment><![CDATA[Object ID of task used for very time-critical command execution (Motion-Execution-Task)]]></Comment>
+								<BitSize>32</BitSize>
+								<BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+								<PTCID>#x03002060</PTCID>
+							</Parameter>
+							<Parameter ReadOnly="true">
+								<Name>Preparation-Task OID (MPT)</Name>
+								<Comment><![CDATA[Object ID of task used for less time-critical command preparation (Motion-Preparation-Task)]]></Comment>
+								<BitSize>32</BitSize>
+								<BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+								<PTCID>#x03002061</PTCID>
+							</Parameter>
+							<Parameter ReadOnly="true">
+								<Name>Job-Task OID (MJT)</Name>
+								<Comment><![CDATA[Object ID of JobTask for asynchronous processing (Motion-Job-Task)]]></Comment>
+								<BitSize>32</BitSize>
+								<BaseType GUID="{18071995-0000-0000-0000-00000000000F}">OTCID</BaseType>
+								<Properties>
+									<Property>
+										<Name>TcJobTaskOID</Name>
+									</Property>
+								</Properties>
+								<PTCID>#x0300a11b</PTCID>
+							</Parameter>
+						</Parameters>
+						<Properties>
+							<Property>
+								<Name>Category</Name>
+								<Value>TcNc3Instance</Value>
+							</Property>
+							<Property>
+								<Name>Category</Name>
+								<Value>HideTcComContextPP</Value>
+							</Property>
+							<Property>
+								<Name>ChildCategory</Name>
+								<Value>MC Object</Value>
+							</Property>
+						</Properties>
+						<ParentOTCID>#x05000010</ParentOTCID>
+						<ParameterValues>
+							<Value>
+								<Name>Execution-Task OID (MET)</Name>
+								<Value>83886096</Value>
+							</Value>
+							<Value>
+								<Name>Preparation-Task OID (MPT)</Name>
+								<Value>83886112</Value>
+							</Value>
+							<Value>
+								<Name>Job-Task OID (MJT)</Name>
+								<Value>33620080</Value>
+							</Value>
+						</ParameterValues>
+					</TmcDesc>
+				</Instance>
 				<Modules>
 					<Module Id="#x05120010">
 						<Name>Collision Avoidance</Name>
@@ -40032,18 +40107,12 @@ External Setpoint Generation:
 							</ParameterValues>
 						</TmcDesc>
 					</Module>
-					<Parameters>
-						<Parameter>
-							<PTCID>#x300a11b</PTCID>
-							<Data>02010070</Data>
-						</Parameter>
-					</Parameters>
 				</Modules>
 			</NC>
 		</Motion>
 		<Plc>
 			<Project GUID="{DD3A0B29-8E7C-4E32-989D-B0222C998777}" Name="PLC1" PrjFilePath="PLC1\PLC1.plcproj" TmcFilePath="PLC1\PLC1.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{50E81325-C29F-8BEF-8016-B9B16553B55E}" TmcPath="PLC1\PLC1.tmc">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcHash="{7A4E687C-6E41-89DB-DDC1-A5D0E9D70298}" TmcPath="PLC1\PLC1.tmc">
 					<Name>PLC1 Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Vars VarGrpType="2" AreaNo="1">
@@ -40119,6 +40188,7 @@ External Setpoint Generation:
 							<CycleTime>1000000</CycleTime>
 						</Context>
 					</Contexts>
+					<JsonDynPous><![CDATA[null]]></JsonDynPous>
 					<TaskPouOids>
 						<TaskPouOid Prio="6" OTCID="#x08502001"/>
 					</TaskPouOids>

--- a/Base Project/PLC1/GVLs/Param.TcGVL
+++ b/Base Project/PLC1/GVLs/Param.TcGVL
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.18">
   <GVL Name="Param" Id="{673621fc-c806-000b-08ea-fd34161e1bd8}" ParameterList="True">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
 	// The following should be set to a value **equal to or greater than** the number of objects needed
 	MAX_MOVERS   			: USINT := 100;	// Movers
+	MAX_MOVERLISTS			: USINT := 100;	// Mover Lists
 	MAX_POSITIONTRIGGERS	: USINT := 100;	// Position triggers
 	MAX_STATIONS			: USINT := 100;	// Stations
 	MAX_ZONES				: USINT := 100;	// Zones

--- a/Base Project/PLC1/PLC1.plcproj
+++ b/Base Project/PLC1/PLC1.plcproj
@@ -8,7 +8,7 @@
     <WriteProductVersion>true</WriteProductVersion>
     <GenerateTpy>false</GenerateTpy>
     <Name>PLC1</Name>
-    <ProgramVersion>3.1.4026.21</ProgramVersion>
+    <ProgramVersion>3.1.4026.24</ProgramVersion>
     <Application>{4aad4b07-8544-4a4a-85a6-bcc87a471a4a}</Application>
     <TypeSystem>{2d2f50a8-8039-4540-9b70-b5591df2aca6}</TypeSystem>
     <Implicit_Task_Info>{f651b4e4-4e5e-4ff5-98bf-9ff99fb35d4a}</Implicit_Task_Info>

--- a/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.17">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.18">
   <POU Name="Mediator" Id="{164d51b4-07ec-0e46-0eb0-392af39d7d3a}" SpecialFunc="None">
     <Declaration><![CDATA[{attribute 'reflection'}
 FUNCTION_BLOCK Mediator
@@ -7,7 +7,7 @@ VAR_INPUT
 
 	MoverArray				: ARRAY [1..Param.MAX_MOVERS] OF POINTER TO Mover;
 	
-	MoverListArray			: ARRAY [0..Param.NUM_MOVERLISTS-1] OF POINTER TO MoverList;
+	MoverListArray			: ARRAY [0..Param.MAX_MOVERLISTS-1] OF POINTER TO MoverList;
 	PositionTriggerArray	: ARRAY [0..Param.MAX_POSITIONTRIGGERS-1] OF POINTER TO PositionTrigger;
 	StationArray			: ARRAY [0..Param.MAX_STATIONS-1] OF POINTER TO Station;
 	ZoneArray				: ARRAY [0..Param.MAX_ZONES-1] OF POINTER TO Zone;
@@ -136,7 +136,7 @@ END_IF
 internalMoverListRecalc := TRUE;]]></ST>
       </Implementation>
     </Method>
-    <Method Name="AddMoverList" Id="{fa372345-a99c-01d2-2d94-cc2fd6bab53d}">
+    <Method Name="AddMoverList" Id="{fa372345-a99c-01d2-2d94-cc2fd6bab53d}" FolderPath="Methods\">
       <Declaration><![CDATA[METHOD AddMoverList : BOOL
 VAR_INPUT
 	

--- a/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Administrative/Mediator.TcPOU
@@ -106,7 +106,7 @@ IF __ISVALIDREF( Mover ) THEN
 	END_FOR
 	
 	// if no empty index is available set a message and return
-	IF emptyIDX = -1 THEN
+	IF duplicateFound = FALSE AND emptyIDX = -1 THEN
 		ADSLOGSTR( ADSLOG_MSGTYPE_WARN, 'AddMover System Array is full. %s not added. Check Params.MAX_MOVERS' , Mover.InstancePath);
 		RETURN;
 	END_IF;
@@ -174,7 +174,7 @@ IF __ISVALIDREF( MoverList ) THEN
 	END_FOR
 	
 	// if no empty index is available set a message and return
-	IF emptyIDX = -1 THEN
+	IF duplicateFound = FALSE AND emptyIDX = -1 THEN
 		ADSLOGSTR( ADSLOG_MSGTYPE_WARN, 'MoverList System Array is full. %s not added. Check Params.MAX_MOVERLISTS' , MoverList.InstancePath);
 		RETURN;
 	END_IF;
@@ -226,7 +226,7 @@ IF __ISVALIDREF( PositionTrigger ) THEN
 	END_FOR
 	
 	// if no empty index is available set a message and return
-	IF emptyIDX = -1 THEN
+	IF duplicateFound = FALSE AND emptyIDX = -1 THEN
 		ADSLOGSTR( ADSLOG_MSGTYPE_WARN, 'AddPositionTrigger System Array is full. %s not added. Check Params.MAX_POSITIONTRIGGERS' , PositionTrigger.InstancePath);
 		RETURN;
 	END_IF;
@@ -283,7 +283,7 @@ IF __ISVALIDREF( Station ) THEN
 	END_FOR
 	
 	// if no empty index is available set a message and return
-	IF emptyIDX = -1 THEN
+	IF duplicateFound = FALSE AND emptyIDX = -1 THEN
 		ADSLOGSTR( ADSLOG_MSGTYPE_WARN, 'AddStation System Array is full. %s not added. Check Params.MAX_STATIONS' , Station.InstancePath);
 		RETURN;
 	END_IF;
@@ -377,7 +377,7 @@ IF __ISVALIDREF( Zone ) THEN
 	END_FOR
 	
 	// if no empty index is available set a message and return
-	IF emptyIDX = -1 THEN
+	IF duplicateFound = FALSE AND emptyIDX = -1 THEN
 		ADSLOGSTR( ADSLOG_MSGTYPE_WARN, 'AddZone System Array is full. %s not added. Check Params.MAX_ZONES' , Zone.InstancePath);
 		RETURN;
 	END_IF;

--- a/Base Project/PLC1/XTS (Do Not Edit)/Objects/Mover.TcPOU
+++ b/Base Project/PLC1/XTS (Do Not Edit)/Objects/Mover.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.13">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.18">
   <POU Name="Mover" Id="{461a92b9-026e-4cbb-aa50-b18297f25ecc}" SpecialFunc="None">
     <Declaration><![CDATA[{attribute 'reflection'}
 FUNCTION_BLOCK Mover IMPLEMENTS iMover;
@@ -1950,7 +1950,7 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[
-FOR i := 0 TO Param.NUM_MOVERLISTS-1 DO
+FOR i := 0 TO Param.MAX_MOVERLISTS-1 DO
 	Mediator.MoverListArray[i]^.UnregisterMover( THIS^ );
 END_FOR
 


### PR DESCRIPTION
- Suppress incorrect "list full" messages when adding items to the mediator that area already registered.
- Make MoverLists use MAX_ and NUM_ parameters like stations, zones, etc.